### PR TITLE
Pass message along if it is a string already

### DIFF
--- a/lib/dog_collar/contrib/rails/lograge/delegating_logger.rb
+++ b/lib/dog_collar/contrib/rails/lograge/delegating_logger.rb
@@ -9,6 +9,8 @@ module DogCollar
         class DelegatingLogger < DogCollar::Logging::Delegator
           %i[debug info warn error fatal].each do |method_name|
             define_method(method_name) do |data|
+              return logger.send(method_name, data) if data.is_a? String
+
               logger.send(method_name, build_message(**data), data)
             end
           end

--- a/spec/contrib/rails/lograge/delegating_logger_spec.rb
+++ b/spec/contrib/rails/lograge/delegating_logger_spec.rb
@@ -23,4 +23,10 @@ describe DogCollar::Contrib::Rails::Lograge::DelegatingLogger do
     expect(logger).to receive(:debug).with(message, data)
     subject.send(:debug, data)
   end
+
+  it "passes the message along unchanged if it is already a string" do
+    message = 'test message'
+    expect(logger).to receive(:debug).with(message)
+    subject.send(:debug, message)
+  end
 end


### PR DESCRIPTION
Extended to support strings in DogCollar::Contrib::Rails::Lograge::DelegatingLogger. If it's a string you, log the string as-is without attempting to build a custom message.